### PR TITLE
core: Fix forwarding of stores starting before the load address

### DIFF
--- a/gwpsan/core/store_buffer.cpp
+++ b/gwpsan/core/store_buffer.cpp
@@ -26,11 +26,21 @@ uptr StoreBuffer::Forward(Addr addr, ByteSize size, uptr val) {
   size = min(size, Sizeof(val));
   for (uptr i = 0; i < buffer_.size(); i++) {
     const auto& store = buffer_[(pos_ + i) % buffer_.size()];
-    auto off = store.addr - addr;
-    if (off >= size)
-      continue;
-    auto n = min(store.size, size - off);
-    internal_memcpy(reinterpret_cast<char*>(&val) + Bytes(off), &store.val.val,
+    const auto store_end = store.addr + store.size;
+    const auto load_end = addr + size;
+    // Note: we can't subtract store.addr from addr directly because both are
+    // unsigned and a store that starts before the load would underflow.
+    const auto overlap_start = max(store.addr, addr);
+    if (overlap_start >= min(store_end, load_end))
+      continue;  // no overlap
+    // Byte offsets of the overlapping part relative to the start of the
+    // load value and of the store value.
+    const auto load_off = overlap_start - addr;
+    const auto store_off = overlap_start - store.addr;
+    const auto n = min(store_end, load_end) - overlap_start;
+    internal_memcpy(reinterpret_cast<char*>(&val) + Bytes(load_off),
+                    reinterpret_cast<const char*>(&store.val.val) +
+                        Bytes(store_off),
                     Bytes(n));
   }
   return val;

--- a/gwpsan/core/store_buffer_test.cpp
+++ b/gwpsan/core/store_buffer_test.cpp
@@ -76,6 +76,15 @@ TEST(StoreBuffer, Test) {
         Access{0x103, 2, 0xdddddddddddddddd},
       },
     },
+    // Stores that start before the load address but still overlap it.
+    {
+      0xbbbbbbbb, Access{0x104, 4, 0xaaaaaaaa},
+      {Access{0x100, 8, 0xbbbbbbbbbbbbbbbb}},
+    },
+    {
+      0x33445566, Access{0x102, 4, 0xdeadbeef},
+      {Access{0x100, 8, 0x1122334455667788}},
+    },
   };
   // clang-format on
   for (auto& test : tests) {


### PR DESCRIPTION
## What

`StoreBuffer::Forward` replays previously-emulated stores into a value being loaded, to reconstruct what memory would actually contain. It computed the overlap offset as:

```cpp
auto off = store.addr - addr;
```

Both are unsigned, so when a store starts *before* the load address but still overlaps it (e.g. an 8-byte store at `X` followed by a 4-byte load at `X+4`), `off` wraps to a huge value, the `off >= size` check skips the store, and the loaded value is wrong.

The existing tests only covered stores that start at or after the load address (including the non-overlapping case at `0x100`/`0x104`), so this direction was untested.

## Why

This is reachable in normal emulated code: any sequence that writes a wider value and then reads a narrower overlapping field at a higher offset (e.g. writing a 64-bit value and reading its high 32 bits) produces a wrong value during emulation when the store happens to still be in the ring buffer.

## Fix

Compute the overlapping range explicitly using `max(store.addr, addr)` / `min(store_end, load_end)`, derive the byte offsets within both the load value and the store value, and copy only the overlapping bytes. This preserves the existing right-overlap behavior and fixes left-overlap.

Added test cases for stores that start before the load address:
- store 8 bytes at `0x100`, load 4 bytes at `0x104` → `0xbbbbbbbb` (was `0xaaaaaaaa`)
- store 8 bytes at `0x100`, load 4 bytes at `0x102` → `0x33445566`